### PR TITLE
feat: group & rename the CDK Flows selector (AgeKit+ API / CDK API / CDK Widgets)

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -90,7 +90,7 @@ npm run dev
 
 k-ID Dev Explorerは、k-ID CDKフローをテストするためのインタラクティブな方法を提供します：
 
-1. **フローを選択**: ドロップダウンメニューからCDKフロータイプを選択します（例：Age Gate、Access Age Verification、Age Appealなど）
+1. **フローを選択**: ドロップダウンメニューからCDKフロータイプを選択します（例：Age Gate Widget、Access Age Verification、Age Appealなど）
 
 2. **必要なフィールドを入力**: 選択したフローに必要なフィールドを入力します：
    - **管轄区域**: ほとんどのフローで必要です（例：「US-CA」、「GB」）
@@ -117,9 +117,11 @@ k-ID Dev Explorerは、k-ID CDKフローをテストするためのインタラ�
 
 ### 利用可能なCDKフロー
 
+セレクターはフローを **AgeKit+ API**（年齢保証手段）、**CDK API**（サーバーサイド CDK エンドポイント）、**CDK ウィジェット**（iframe に埋め込む生成済みウィジェット URL）に分類します。
+
+**AgeKit+ API**
+
 - **Access Age Verification**: アクセス許可前にユーザーの年齢を確認
-- **Age Gate**: ユーザーに年齢確認オプションを提示
-- **Age Gate Check**: サーバーサイドCDKカスタムフロー。年齢ゲート要件をチェックし、年齢保証が必要な場合はチャレンジを返す
 - **Facial Age Estimation**: 顔認識を使用して年齢を推定
 - **ID Verification**: 政府発行の身分証明書で身元を確認
 - **AgeKey Verification**: パスキーによる年齢確認
@@ -127,10 +129,18 @@ k-ID Dev Explorerは、k-ID CDKフローをテストするためのインタラ�
 - **Email Age Estimation**: メールアドレスから年齢を推定
 - **Trusted Adult Verification**: 信頼できる成人の確認を通じて確認
 - **Age Appeal**: ユーザーが年齢確認決定に異議を申し立てることを許可
-- **VPC End-to-End**: 完全な検証、同意、および許可フロー
-- **Direct Notices**: コンプライアンス通知を直接表示
-- **Manage Session Permissions**: 既存セッションの権限を管理
+
+**CDK API**
+
+- **Age Gate Check**: サーバーサイドCDKカスタムフロー。年齢ゲート要件をチェックし、年齢保証が必要な場合はチャレンジを返す
 - **Session Upgrade Age Assurance**: 年齢保証が必要な権限で既存のセッションをアップグレード
+
+**CDK ウィジェット**
+
+- **Age Gate Widget**: ユーザーに年齢確認オプションを提示
+- **End-to-End Widget**: 完全な検証、同意、および許可フロー（VPC）
+- **Direct Notices Widget**: コンプライアンス通知を直接表示
+- **Manage Session Permissions Widget**: 既存セッションの権限を管理
 
 各フローの詳細なドキュメントについては、[k-ID Developer Hub](https://docs.k-id.com)をご覧ください。
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -90,7 +90,7 @@ npm run dev
 
 k-ID Dev Explorer는 k-ID CDK 플로우를 테스트하는 대화형 방법을 제공합니다:
 
-1. **플로우 선택**: 드롭다운 메뉴에서 CDK 플로우 타입을 선택합니다(예: Age Gate, Access Age Verification, Age Appeal 등)
+1. **플로우 선택**: 드롭다운 메뉴에서 CDK 플로우 타입을 선택합니다(예: Age Gate Widget, Access Age Verification, Age Appeal 등)
 
 2. **필수 필드 입력**: 선택한 플로우에 필요한 필드를 입력합니다:
    - **관할권**: 대부분의 플로우에 필요합니다(예: "US-CA", "GB")
@@ -117,9 +117,11 @@ k-ID Dev Explorer는 k-ID CDK 플로우를 테스트하는 대화형 방법을 �
 
 ### 사용 가능한 CDK 플로우
 
+선택기는 플로우를 **AgeKit+ API**(연령 보증 수단), **CDK API**(서버 사이드 CDK 엔드포인트), **CDK 위젯**(iframe에 임베드되는 생성된 위젯 URL)으로 분류합니다.
+
+**AgeKit+ API**
+
 - **Access Age Verification**: 액세스 권한 부여 전에 사용자의 연령을 확인
-- **Age Gate**: 사용자에게 연령 확인 옵션 제공
-- **Age Gate Check**: 서버 사이드 CDK 커스텀 플로우로, 연령 게이트 요구 사항을 확인하고 연령 보증이 필요할 때 챌린지를 반환
 - **Facial Age Estimation**: 얼굴 인식을 사용하여 연령 추정
 - **ID Verification**: 정부 발급 신분증을 사용하여 신원 확인
 - **AgeKey Verification**: 패스키를 사용한 연령 확인
@@ -127,10 +129,18 @@ k-ID Dev Explorer는 k-ID CDK 플로우를 테스트하는 대화형 방법을 �
 - **Email Age Estimation**: 이메일 주소로 연령 추정
 - **Trusted Adult Verification**: 신뢰할 수 있는 성인 확인을 통해 확인
 - **Age Appeal**: 사용자가 연령 확인 결정에 대해 이의를 제기할 수 있도록 허용
-- **VPC End-to-End**: 완전한 확인, 동의 및 권한 플로우
-- **Direct Notices**: 컴플라이언스 공지를 직접 표시
-- **Manage Session Permissions**: 기존 세션의 권한 관리
+
+**CDK API**
+
+- **Age Gate Check**: 서버 사이드 CDK 커스텀 플로우로, 연령 게이트 요구 사항을 확인하고 연령 보증이 필요할 때 챌린지를 반환
 - **Session Upgrade Age Assurance**: 연령 보증이 필요한 권한으로 기존 세션 업그레이드
+
+**CDK 위젯**
+
+- **Age Gate Widget**: 사용자에게 연령 확인 옵션 제공
+- **End-to-End Widget**: 완전한 확인, 동의 및 권한 플로우 (VPC)
+- **Direct Notices Widget**: 컴플라이언스 공지를 직접 표시
+- **Manage Session Permissions Widget**: 기존 세션의 권한 관리
 
 각 플로우에 대한 자세한 문서는 [k-ID Developer Hub](https://docs.k-id.com)를 방문하세요.
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -90,7 +90,7 @@ npm run dev
 
 k-ID Dev Explorer 提供了一种交互式方法来测试 k-ID CDK 流程：
 
-1. **选择流程**：从下拉菜单中选择 CDK 流程类型（例如：Age Gate、Access Age Verification、Age Appeal 等）
+1. **选择流程**：从下拉菜单中选择 CDK 流程类型（例如：Age Gate Widget、Access Age Verification、Age Appeal 等）
 
 2. **输入必填字段**：为所选流程填写必要的字段：
    - **管辖区**：大多数流程需要（例如："US-CA"、"GB"）
@@ -117,9 +117,11 @@ k-ID Dev Explorer 提供了一种交互式方法来测试 k-ID CDK 流程：
 
 ### 可用的 CDK 流程
 
+选择器将流程分为 **AgeKit+ API**（年龄保证方式）、**CDK API**（服务端 CDK 端点）和 **CDK 小部件**（嵌入 iframe 的生成式部件 URL）：
+
+**AgeKit+ API**
+
 - **Access Age Verification**：在授予访问权限之前验证用户的年龄
-- **Age Gate**：向用户展示年龄验证选项
-- **Age Gate Check**：服务端 CDK 自定义流程，检查年龄门要求；需要年龄保证时返回一个 challenge
 - **Facial Age Estimation**：使用面部识别估计年龄
 - **ID Verification**：使用政府颁发的身份证件验证身份
 - **AgeKey Verification**：基于通行密钥的年龄验证
@@ -127,10 +129,18 @@ k-ID Dev Explorer 提供了一种交互式方法来测试 k-ID CDK 流程：
 - **Email Age Estimation**：根据电子邮件地址估计年龄
 - **Trusted Adult Verification**：通过受信任的成人确认进行验证
 - **Age Appeal**：允许用户对年龄验证决定提出申诉
-- **VPC End-to-End**：完整的验证、同意和权限流程
-- **Direct Notices**：直接显示合规通知
-- **Manage Session Permissions**：管理现有会话的权限
+
+**CDK API**
+
+- **Age Gate Check**：服务端 CDK 自定义流程，检查年龄门要求；需要年龄保证时返回一个 challenge
 - **Session Upgrade Age Assurance**：使用需要年龄保证的权限升级现有会话
+
+**CDK 小部件**
+
+- **Age Gate Widget**：向用户展示年龄验证选项
+- **End-to-End Widget**：完整的验证、同意和权限流程（VPC）
+- **Direct Notices Widget**：直接显示合规通知
+- **Manage Session Permissions Widget**：管理现有会话的权限
 
 每个流程的详细文档，请访问 [k-ID Developer Hub](https://docs.k-id.com)。
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ When developing locally, **age key creation and validation will not work** unles
 
 The k-ID Dev Explorer provides an interactive way to test k-ID CDK flows:
 
-1. **Select a Flow**: Choose a CDK flow type from the dropdown menu (e.g., Age Gate, Access Age Verification, Age Appeal, etc.)
+1. **Select a Flow**: Choose a CDK flow type from the dropdown menu (e.g., Age Gate Widget, Access Age Verification, Age Appeal, etc.)
 
 2. **Enter Required Fields**: Fill in the necessary fields for the selected flow:
    - **Jurisdiction**: Required for most flows (e.g., "US-CA", "GB")
@@ -119,9 +119,11 @@ The k-ID Dev Explorer provides an interactive way to test k-ID CDK flows:
 
 ### Available CDK Flows
 
+The selector groups flows into **AgeKit+ API** (age assurance methods), **CDK API** (server-side CDK endpoints), and **CDK Widgets** (hosted widget URLs embedded in the iframe):
+
+**AgeKit+ API**
+
 - **Access Age Verification**: Verify a user's age before granting access
-- **Age Gate**: Present age verification options to users
-- **Age Gate Check**: Server-side CDK Custom flow that checks age gate requirements and returns a challenge when age assurance is needed
 - **Facial Age Estimation**: Estimate age using facial recognition
 - **ID Verification**: Verify identity using government-issued ID
 - **AgeKey Verification**: Passkey-based age verification
@@ -129,10 +131,18 @@ The k-ID Dev Explorer provides an interactive way to test k-ID CDK flows:
 - **Email Age Estimation**: Estimate age from an email address
 - **Trusted Adult Verification**: Verify through trusted adult confirmation
 - **Age Appeal**: Allow users to appeal an age verification decision
-- **VPC End-to-End**: Complete verification, consent, and permission flow
-- **Direct Notices**: Display compliance notices directly
-- **Manage Session Permissions**: Manage permissions for an existing session
+
+**CDK API**
+
+- **Age Gate Check**: Server-side CDK Custom flow that checks age gate requirements and returns a challenge when age assurance is needed
 - **Session Upgrade Age Assurance**: Upgrade an existing session with permissions that require age assurance
+
+**CDK Widgets**
+
+- **Age Gate Widget**: Present age verification options to users
+- **End-to-End Widget**: Complete verification, consent, and permission flow (VPC)
+- **Direct Notices Widget**: Display compliance notices directly
+- **Manage Session Permissions Widget**: Manage permissions for an existing session
 
 For detailed documentation on each flow, visit the [k-ID Developer Hub](https://docs.k-id.com).
 

--- a/app/cdk-flows/CDKFlowDevTool.tsx
+++ b/app/cdk-flows/CDKFlowDevTool.tsx
@@ -15,6 +15,54 @@ interface ApiKeyStatus {
   apiUrl: string
 }
 
+/**
+ * Flow selector grouping. The order here (deliberately NOT alphabetical) drives
+ * the dropdown, split into AgeKit+ API (age assurance methods), CDK API
+ * (server-side CDK endpoints), and CDK Widgets (hosted widget URLs). A native
+ * <select> supports a single <optgroup> level, so each group renders as one
+ * <optgroup>; option labels come from the flows.* translations.
+ */
+const FLOW_GROUPS: { labelKey: string; flows: CDKFlow[] }[] = [
+  {
+    labelKey: 'flowGroups.agekitApi',
+    flows: [
+      CDKFlow.ACCESS_AGE_VERIFICATION,
+      CDKFlow.FACIAL_AGE_ESTIMATION,
+      CDKFlow.ID_VERIFICATION,
+      CDKFlow.AGE_KEY_VERIFICATION,
+      CDKFlow.CONNECT_ID_VERIFICATION,
+      CDKFlow.EMAIL_ESTIMATION,
+      CDKFlow.TRUSTED_ADULT_VERIFICATION,
+      CDKFlow.AGE_APPEAL,
+    ],
+  },
+  {
+    labelKey: 'flowGroups.cdkApi',
+    flows: [CDKFlow.AGE_GATE_CHECK, CDKFlow.SESSION_UPGRADE_AGE_ASSURANCE],
+  },
+  {
+    labelKey: 'flowGroups.cdkWidgets',
+    flows: [
+      CDKFlow.AGE_GATE,
+      CDKFlow.END_TO_END,
+      CDKFlow.DIRECT_NOTICES,
+      CDKFlow.MANAGE_SESSION_PERMISSIONS,
+    ],
+  },
+]
+
+// ACCESS_AGE_VERIFICATION -> accessAgeVerification (matches the flows.* keys).
+function flowTranslationKey(flow: CDKFlow): string {
+  const flowKey = (Object.keys(CDKFlow) as (keyof typeof CDKFlow)[]).find((k) => CDKFlow[k] === flow)
+  return flowKey
+    ? flowKey
+        .toLowerCase()
+        .split('_')
+        .map((word, i) => (i === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1)))
+        .join('')
+    : ''
+}
+
 interface CDKFlowDevToolProps {
   onIframeUrlUpdate?: (
     url: string,
@@ -427,18 +475,15 @@ export default function CDKFlowDevTool({ onIframeUrlUpdate, apiKeyStatus, onAddE
               className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
               required
             >
-              {Object.values(CDKFlow).sort().map((value, index) => {
-                const flowKey = Object.keys(CDKFlow).find(key => CDKFlow[key as keyof typeof CDKFlow] === value);
-                // Convert ACCESS_AGE_VERIFICATION to accessAgeVerification (camelCase)
-                const translationKey = flowKey
-                  ? flowKey.toLowerCase().split('_').map((word, i) => i === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1)).join('')
-                  : '';
-                return (
-                  <option key={index} value={value}>
-                    {t(`flows.${translationKey}`) || value}
-                  </option>
-                );
-              })}
+              {FLOW_GROUPS.map((group) => (
+                <optgroup key={group.labelKey} label={t(group.labelKey)}>
+                  {group.flows.map((flow) => (
+                    <option key={flow} value={flow}>
+                      {t(`flows.${flowTranslationKey(flow)}`) || flow}
+                    </option>
+                  ))}
+                </optgroup>
+              ))}
             </select>
           </div>
           {ageCriteriaFlows.has(selectedFlow) && (

--- a/app/cdk-flows/CDKFlowDevTool.tsx
+++ b/app/cdk-flows/CDKFlowDevTool.tsx
@@ -1,5 +1,5 @@
 import { formatErrorForDisplay } from '../utils/errorUtils'
-import { AddEventMethod, CDKFlow, EventLog, FormEntryKey, RequestType } from './types'
+import { AddEventMethod, CDKFlow, EventDetails, EventLog, FormEntryKey, RequestType } from './types'
 import { performCDKFlow } from './serverActions'
 import { useState, useEffect, useCallback, useRef } from 'react'
 import QRCode from 'qrcode'
@@ -61,7 +61,7 @@ export default function CDKFlowDevTool({ onIframeUrlUpdate, apiKeyStatus, onAddE
   const [qrCodeDataUrl, setQrCodeDataUrl] = useState<string>('')
 
   // Add event to log - use useCallback to ensure the function reference is stable
-  const addEvent = useCallback((event: string, type: RequestType = RequestType.INFO, details?: unknown) => {
+  const addEvent = useCallback((event: string, type: RequestType = RequestType.INFO, details?: EventDetails) => {
     const newEvent: EventLog = {
       timestamp: new Date().toLocaleTimeString(),
       event,
@@ -362,10 +362,10 @@ export default function CDKFlowDevTool({ onIframeUrlUpdate, apiKeyStatus, onAddE
       }
     } else if (event.event === 'api-response') {
       // For API responses, copy the response data
-      textToCopy = JSON.stringify(event.details.responseData, null, 2)
+      textToCopy = JSON.stringify(event.details?.responseData, null, 2)
     } else if (event.event === 'webhook-received') {
       // For webhook events, copy just the body payload
-      textToCopy = JSON.stringify(event.details.body, null, 2)
+      textToCopy = JSON.stringify(event.details?.body, null, 2)
     } else if (event.event === 'js-message') {
       // For JS messages, copy just the message data
       textToCopy = JSON.stringify(event.details, null, 2)

--- a/app/cdk-flows/types.ts
+++ b/app/cdk-flows/types.ts
@@ -6,11 +6,34 @@ export enum RequestType {
   WEBHOOK = 'webhook',
 }
 
+/**
+ * Loosely-typed payload attached to an {@link EventLog}. The shape varies by
+ * event (api-request / api-response / webhook-received / *-error / js-message),
+ * so the commonly-read fields are declared and an index signature keeps
+ * arbitrary writers valid. Declared as typed rather than `unknown` so the event
+ * log/copy/download code can read fields without truthiness narrowing to `{}`.
+ */
+export interface EventDetails {
+  method?: string
+  url?: string
+  body?: unknown
+  headers?: unknown
+  id?: string
+  shortUrl?: string
+  challengeId?: string
+  sessionId?: string
+  responseData?: unknown
+  error?: unknown
+  signatureStatus?: string
+  timestamp?: string
+  [key: string]: unknown
+}
+
 export interface EventLog {
   timestamp: string
   event: string
   type?: RequestType
-  details?: unknown
+  details?: EventDetails
 }
 
 export interface FlowRequestData {
@@ -138,7 +161,7 @@ export type RequestBody = {
   options?: RequestBodyE2EOptions
 }
 
-export type AddEventMethod = (event: string, type: RequestType, details?: unknown) => void
+export type AddEventMethod = (event: string, type: RequestType, details?: EventDetails) => void
 
 export enum AgeType {
   AGE = 'Age',

--- a/app/components/ChallengeControls.tsx
+++ b/app/components/ChallengeControls.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { getChallengeStatus } from '../cdk-flows/serverActions'
-import { RequestType } from '../cdk-flows/types'
+import { EventDetails, RequestType } from '../cdk-flows/types'
 
 interface ApiKeyStatus {
   isConfigured: boolean
@@ -12,7 +12,7 @@ interface ApiKeyStatus {
 interface ChallengeControlsProps {
   challengeId: string | null
   apiKeyStatus: ApiKeyStatus
-  addEvent?: (event: string, type?: RequestType, details?: unknown) => void
+  addEvent?: (event: string, type?: RequestType, details?: EventDetails) => void
 }
 
 export default function ChallengeControls({ challengeId, apiKeyStatus, addEvent }: ChallengeControlsProps) {

--- a/app/components/DevToolWrapper.tsx
+++ b/app/components/DevToolWrapper.tsx
@@ -6,7 +6,7 @@ import IframeDisplay from './IframeDisplay'
 import ChallengeControls from './ChallengeControls'
 import SessionControls from './SessionControls'
 import EventsTraffic from './EventsTraffic'
-import { AddEventMethod, EventLog, RequestType } from '../cdk-flows/types'
+import { AddEventMethod, EventDetails, EventLog, RequestType } from '../cdk-flows/types'
 
 interface ApiKeyStatus {
   isConfigured: boolean
@@ -32,7 +32,7 @@ export default function DevToolWrapper({ apiKeyStatus }: DevToolWrapperProps) {
   const copyEventRef = useRef<((event: EventLog) => void) | undefined>(undefined)
 
   // Create a stable event handler function with useCallback
-  const addEvent = useCallback((event: string, type?: string, details?: unknown) => {
+  const addEvent = useCallback((event: string, type?: string, details?: EventDetails) => {
     if (addEventFnRef.current) {
       addEventFnRef.current(event, (type as RequestType) || RequestType.INFO, details)
     }

--- a/app/components/SessionControls.tsx
+++ b/app/components/SessionControls.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { getSessionStatus } from '../cdk-flows/serverActions'
-import { RequestType } from '../cdk-flows/types'
+import { EventDetails, RequestType } from '../cdk-flows/types'
 
 interface ApiKeyStatus {
   isConfigured: boolean
@@ -12,7 +12,7 @@ interface ApiKeyStatus {
 interface SessionControlsProps {
   sessionId: string | null
   apiKeyStatus: ApiKeyStatus
-  addEvent?: (event: string, type?: RequestType, details?: unknown) => void
+  addEvent?: (event: string, type?: RequestType, details?: EventDetails) => void
 }
 
 export default function SessionControls({ sessionId, apiKeyStatus, addEvent }: SessionControlsProps) {

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -67,14 +67,14 @@
     "accessAgeVerification": "Access Age Verification",
     "facialAgeEstimation": "Facial Age Estimation",
     "trustedAdultVerification": "Trusted Adult Verification",
-    "ageGate": "Age Gate",
+    "ageGate": "Age Gate Widget",
     "idVerification": "ID Verification",
     "ageKeyVerification": "AgeKey Verification",
     "connectIdVerification": "ConnectID Verification",
     "emailEstimation": "Email Age Estimation",
-    "endToEnd": "VPC End-to-End",
-    "directNotices": "Direct Notices",
-    "manageSessionPermissions": "Manage Session Permissions",
+    "endToEnd": "End-to-End Widget",
+    "directNotices": "Direct Notices Widget",
+    "manageSessionPermissions": "Manage Session Permissions Widget",
     "ageAppeal": "Age Appeal",
     "sessionUpgradeAgeAssurance": "Session Upgrade Age Assurance",
     "ageGateCheck": "Age Gate Check"
@@ -130,6 +130,10 @@
   "errors": {
     "apiKeyNotConfigured": "API key not configured. Please set K_ID_API_KEY in your .env.local file.",
     "anErrorOccurred": "An error occurred"
+  },
+  "flowGroups": {
+    "agekitApi": "AgeKit+ API",
+    "cdkApi": "CDK API",
+    "cdkWidgets": "CDK Widgets"
   }
 }
-

--- a/app/translations/ja.json
+++ b/app/translations/ja.json
@@ -67,14 +67,14 @@
     "accessAgeVerification": "アクセス年齢確認",
     "facialAgeEstimation": "顔認証による年齢推定",
     "trustedAdultVerification": "信頼できる大人の確認",
-    "ageGate": "年齢ゲート",
+    "ageGate": "年齢ゲートウィジェット",
     "idVerification": "ID確認",
     "ageKeyVerification": "AgeKey確認",
     "connectIdVerification": "ConnectID確認",
     "emailEstimation": "メール年齢推定",
-    "endToEnd": "VPCエンドツーエンド",
-    "directNotices": "直接通知",
-    "manageSessionPermissions": "セッション権限の管理",
+    "endToEnd": "エンドツーエンドウィジェット",
+    "directNotices": "直接通知ウィジェット",
+    "manageSessionPermissions": "セッション権限管理ウィジェット",
     "ageAppeal": "年齢申し立て",
     "sessionUpgradeAgeAssurance": "セッションアップグレード年齢保証",
     "ageGateCheck": "年齢ゲートチェック"
@@ -130,6 +130,10 @@
   "errors": {
     "apiKeyNotConfigured": "APIキーが設定されていません。.env.localファイルでK_ID_API_KEYを設定してください。",
     "anErrorOccurred": "エラーが発生しました"
+  },
+  "flowGroups": {
+    "agekitApi": "AgeKit+ API",
+    "cdkApi": "CDK API",
+    "cdkWidgets": "CDK ウィジェット"
   }
 }
-

--- a/app/translations/ko.json
+++ b/app/translations/ko.json
@@ -67,14 +67,14 @@
     "accessAgeVerification": "접근 연령 확인",
     "facialAgeEstimation": "얼굴 인식 연령 추정",
     "trustedAdultVerification": "신뢰할 수 있는 성인 확인",
-    "ageGate": "연령 게이트",
+    "ageGate": "연령 게이트 위젯",
     "idVerification": "ID 확인",
     "ageKeyVerification": "AgeKey 확인",
     "connectIdVerification": "ConnectID 확인",
     "emailEstimation": "이메일 연령 추정",
-    "endToEnd": "VPC 종단간",
-    "directNotices": "직접 알림",
-    "manageSessionPermissions": "세션 권한 관리",
+    "endToEnd": "종단간 위젯",
+    "directNotices": "직접 알림 위젯",
+    "manageSessionPermissions": "세션 권한 관리 위젯",
     "ageAppeal": "연령 항소",
     "sessionUpgradeAgeAssurance": "세션 업그레이드 연령 보증",
     "ageGateCheck": "연령 게이트 체크"
@@ -130,6 +130,10 @@
   "errors": {
     "apiKeyNotConfigured": "API 키가 구성되지 않았습니다. .env.local 파일에서 K_ID_API_KEY를 설정하세요.",
     "anErrorOccurred": "오류가 발생했습니다"
+  },
+  "flowGroups": {
+    "agekitApi": "AgeKit+ API",
+    "cdkApi": "CDK API",
+    "cdkWidgets": "CDK 위젯"
   }
 }
-

--- a/app/translations/zh.json
+++ b/app/translations/zh.json
@@ -67,14 +67,14 @@
     "accessAgeVerification": "访问年龄验证",
     "facialAgeEstimation": "面部年龄估计",
     "trustedAdultVerification": "可信成人验证",
-    "ageGate": "年龄门控",
+    "ageGate": "年龄门控小部件",
     "idVerification": "ID验证",
     "ageKeyVerification": "AgeKey验证",
     "connectIdVerification": "ConnectID验证",
     "emailEstimation": "电子邮件年龄估计",
-    "endToEnd": "VPC端到端",
-    "directNotices": "直接通知",
-    "manageSessionPermissions": "管理会话权限",
+    "endToEnd": "端到端小部件",
+    "directNotices": "直接通知小部件",
+    "manageSessionPermissions": "管理会话权限小部件",
     "ageAppeal": "年龄申诉",
     "sessionUpgradeAgeAssurance": "会话升级年龄保证",
     "ageGateCheck": "年龄门检查"
@@ -130,6 +130,10 @@
   "errors": {
     "apiKeyNotConfigured": "未配置API密钥。请在.env.local文件中设置K_ID_API_KEY。",
     "anErrorOccurred": "发生错误"
+  },
+  "flowGroups": {
+    "agekitApi": "AgeKit+ API",
+    "cdkApi": "CDK API",
+    "cdkWidgets": "CDK 小部件"
   }
 }
-


### PR DESCRIPTION
## Summary

Two focused changes to the main CDK Flows explorer:

1. **Selector grouping + renaming** — the flow dropdown was a flat, alphabetical list. It's now grouped with `<optgroup>` in a deliberate order:
   - **AgeKit+ API** (age assurance methods): Access Age Verification, Facial Age Estimation, ID Verification, AgeKey, ConnectID, Email Age Estimation, Trusted Adult, Age Appeal
   - **CDK API** (server-side CDK endpoints): Age Gate Check, Session Upgrade Age Assurance
   - **CDK Widgets** (hosted widget URLs embedded in the iframe): Age Gate Widget, End-to-End Widget, Direct Notices Widget, Manage Session Permissions Widget

   The widget-generating flows are renamed to align with the API site (e.g. "VPC End-to-End" → "End-to-End Widget"). Option labels come from `flows.*` translations; group headers from a `flowGroups.*` block (en/ja/ko/zh). Enum values are unchanged, so `flowHandlers` keying and every per-flow form keep working.

2. **Build fix (pre-existing)** — `next build` already failed on `main`: `EventLog.details` was typed `unknown`, so the event-log/copy/download code failed strict type-checking. A typed `EventDetails` fixes it (hence `DevToolWrapper` / `ChallengeControls` / `SessionControls` in the diff). No behavior change.

## Commits
- `fix: type EventLog.details as EventDetails so next build passes`
- `feat: group the CDK Flows selector (AgeKit+ API / CDK API / CDK Widgets)`
- `docs: align README flow list with the grouped selector`

## Testing
- `next build` passes; ESLint clean (only pre-existing `<img>` warnings in `QrCode.tsx`); `tsc --noEmit` reports 0 errors.
- Verified in-browser: the dropdown renders the three `<optgroup>`s (AgeKit+ API / CDK API / CDK Widgets) in order, selecting a flow (including a widget) still switches the correct form, and the event log renders/copies.


<img width="684" height="633" alt="Screenshot 2026-07-27 at 4 20 17 PM" src="https://github.com/user-attachments/assets/ae476dc7-cb01-4fde-a080-e701a74eedc2" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)